### PR TITLE
Be more lenient about children.

### DIFF
--- a/src/react/native/component/props/Props.hx
+++ b/src/react/native/component/props/Props.hx
@@ -1,11 +1,11 @@
 package react.native.component.props;
 
-import haxe.extern.EitherType;
 import react.ReactComponent;
 
 typedef Props = {
 	?ref:Any->Void,
-	?children:EitherType<Child, Array<Child>>,
+	?children:Children,
 }
 
-typedef Child = EitherType<String, ReactElement>;
+@:coreType abstract Children from Array<Child> from Child {}
+@:coreType abstract Child from Bool from String from Int from Float from ReactElement {}


### PR DESCRIPTION
I have some errors here and there when trying to render ints into `Text`. You get `Int should be Null<haxe.extern.EitherType<react.native.component.props.Child, Array<react.native.component.props.Child>>>` which can be a bit intimidating to newcomers ^^