### PR TITLE
fixed getLayout() for AnimatedValueXY

### DIFF
--- a/src/react/native/api/Animated.hx
+++ b/src/react/native/api/Animated.hx
@@ -66,7 +66,7 @@ extern class AnimatedValueXY extends Animated {
 	function stopAnimation(?callback:{x:Float, y:Float}->Void):Void;
 	function addListener(callback:ValueXYListenerCallback):String;
 	function removeListener(id:String):Void;
-	function getLayout(v:{x:AnimatedValue, y:AnimatedValue}):{left:AnimatedValue, top:AnimatedValue};
+	function getLayout():{left:AnimatedValue, top:AnimatedValue};
 	function getTranslateTransform():Array<Dynamic<AnimatedValue>>;
 }
 


### PR DESCRIPTION
getLayout does not require any parameters as it converts internal x,y values